### PR TITLE
Fix timestamp detection

### DIFF
--- a/vtt_to_srt/vtt_to_srt.py
+++ b/vtt_to_srt/vtt_to_srt.py
@@ -12,9 +12,9 @@ def convert_content(file_contents):
        Keyword arguments:
        file_contents
        """
-    replacement = re.sub(r"(\d\d:\d\d:\d\d).(\d\d\d) --> (\d\d:\d\d:\d\d).(\d\d\d)(?:[ \-\w]+:[\w\%\d:]+)*\n", r"\1,\2 --> \3,\4\n", file_contents)
-    replacement = re.sub(r"(\d\d:\d\d).(\d\d\d) --> (\d\d:\d\d).(\d\d\d)(?:[ \-\w]+:[\w\%\d:]+)*\n", r"\1,\2 --> \3,\4\n", replacement)
-    replacement = re.sub(r"(\d\d).(\d\d\d) --> (\d\d).(\d\d\d)(?:[ \-\w]+:[\w\%\d:]+)*\n", r"\1,\2 --> \3,\4\n", replacement)
+    replacement = re.sub(r"(\d\d:\d\d:\d\d).(\d\d\d) --> (\d\d:\d\d:\d\d).(\d\d\d)(?:[ \-\w]+:[\w\%\d:,.]+)*\n", r"\1,\2 --> \3,\4\n", file_contents)
+    replacement = re.sub(r"(\d\d:\d\d).(\d\d\d) --> (\d\d:\d\d).(\d\d\d)(?:[ \-\w]+:[\w\%\d:,.]+)*\n", r"00:\1,\2 --> 00:\3,\4\n", replacement)
+    replacement = re.sub(r"(\d\d).(\d\d\d) --> (\d\d).(\d\d\d)(?:[ \-\w]+:[\w\%\d:,.]+)*\n", r"00:00:\1,\2 --> 00:00:\3,\4\n", replacement)
     replacement = re.sub(r"WEBVTT\n", "", replacement)
     replacement = re.sub(r"Kind:[ \-\w]+\n", "", replacement)
     replacement = re.sub(r"Language:[ \-\w]+\n", "", replacement)
@@ -105,10 +105,10 @@ def walk_tree(top_most_path, callback):
         pathname = os.path.join(top_most_path, f)
         mode = os.stat(pathname)[ST_MODE]
         if S_ISDIR(mode):
-            # It"s a directory, recurse into it
+            # It's a directory, recurse into it
             walk_tree(pathname, callback)
         elif S_ISREG(mode):
-            # It"s a file, call the callback function
+            # It's a file, call the callback function
             callback(pathname)
         else:
             # Unknown file type, print a message
@@ -130,7 +130,7 @@ def walk_dir(top_most_path, callback):
 
 
 def convert_vtt_to_str(f):
-    """Convert vtt fuke to string 
+    """Convert vtt file to string
 
        Keyword arguments:
        f -- file to convert


### PR DESCRIPTION
vtt_to_srt failed for WebVTT input:
```
00:00.500 --> 00:01.730 align:left position:37.5%,start line:93.33% size:62.5%
```

Problems with the existing regular expressions used to match
timestamps:
* They failed to match if the value to a cue setting included
  fractional values.
* They failed to match if a cue setting included comma-separated
  values.
* SubRip requires timestamps to be in a hh:mm:ss,ttt format, but the
  substitution REs did not add `00` for missing fields.

Make the timestamp REs accept `,.` when matching values to cue
settings and to add missing time fields.  Someone who's more familiar
with the WebVTT spec probably should make the REs just follow
whatever the official grammar says.  Alternatively, I'm also inclined
to make it leniently accept *everything* to the end of the line
instead of failing silently (which is another problem).